### PR TITLE
Support GitHub repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ mustached-bear
 
 Clone/Fetch all openstack repos
 
-* Keep your local OpenStack repos up to date.
+* Keep your local not only OpenStack but also GitHub repos up to date.
 * Create a separate directory for each organization
 * skips stackforge repos if that aren't already cloned locally
 * If repo already exists call `git fetch`
@@ -18,3 +18,7 @@ Install requirements:
 Just run in the directory where you wish to keep your repos:
 
     $ ./update
+
+If you want to keep GitHub repos:
+
+    $ ./update --repos-url "https://api.github.com/users/jogo/repos?per_page=1000"

--- a/update
+++ b/update
@@ -53,9 +53,9 @@ class Project(object):
             # the other repo which should be dict and have these keys
             self.full_name = repo['full_name']
             self.org, self.name = repo['owner']['login'], repo['name']
-            # NOTE: Use http_url here because of the GitHub recommendation
+            # NOTE: Use html_url here because of the GitHub recommendation
             # https://help.github.com/articles/which-remote-url-should-i-use/
-            self.git_uri = repo['http_url']
+            self.git_uri = repo['html_url']
 
     def _split_org_name(self):
         try:

--- a/update
+++ b/update
@@ -42,10 +42,20 @@ class GitException(Exception):
 
 
 class Project(object):
-    def __init__(self, full_name):
-        self.full_name = full_name
-        self.org, self.name = self._split_org_name()
-        self.git_uri = self._git_uri()
+    def __init__(self, repo, is_os=True):
+        if (is_os):
+            # OpenStack repo
+            self.full_name = repo
+            self.org, self.name = self._split_org_name()
+            self.git_uri = self._git_uri()
+        else:
+            # Assume a GitHub repo
+            # the other repo which should be dict and have these keys
+            self.full_name = repo['full_name']
+            self.org, self.name = repo['owner']['login'], repo['name']
+            # NOTE: Use http_url here because of the GitHub recommendation
+            # https://help.github.com/articles/which-remote-url-should-i-use/
+            self.git_uri = repo['http_url']
 
     def _split_org_name(self):
         try:
@@ -208,7 +218,7 @@ def skip_project(project_name):
     return project_name in names
 
 
-def main(create_org_dir, delete_orphaned, concurrency):
+def main(create_org_dir, delete_orphaned, concurrency, repos_url):
     def worker():
         """Thread worker."""
         while True:
@@ -226,17 +236,31 @@ def main(create_org_dir, delete_orphaned, concurrency):
         num_worker_threads = concurrency
 
     projects = []
+    projects_json = ""
+    is_os = True
 
-    # List of all openstack repos
-    r = requests.get("https://review.openstack.org:443/projects/")
-    # strip off first few chars because 'the JSON response body starts with a
-    # magic prefix line that must be stripped before feeding the rest of the
-    # response body to a JSON parser'
-    # https://review.openstack.org/Documentation/rest-api.html
-    for name in json.loads(r.text[4:]):
-        if skip_project(name):
+    if (repos_url == 'https://review.openstack.org:443/projects/'):
+        # List of all openstack repos
+        r = requests.get("https://review.openstack.org:443/projects/")
+        # strip off first few chars because 'the JSON response body starts with a
+        # magic prefix line that must be stripped before feeding the rest of the
+        # response body to a JSON parser'
+        # https://review.openstack.org/Documentation/rest-api.html
+        projects_json = r.text[4:]
+    elif (repos_url.find('https://api.github.com/') == 0):
+        # List of all the specified github repos
+        is_os = False
+        r = requests.get(repos_url)
+        # Assume that there's no trick for this URL
+        projects_json = r.text
+    else:
+        print("Unsupported repos_url: %s" % repos_url)
+        sys.exit(1)
+
+    for name in json.loads(projects_json):
+        if is_os and skip_project(name):
             continue
-        projects.append(Project(name))
+        projects.append(Project(name, is_os))
 
     if not create_org_dir:
         _sanity_check(projects)
@@ -273,5 +297,8 @@ if __name__ == "__main__":
     parser.add_argument('--concurrency', '-c', type=int,
                         help='The number of workers to use when running in'
                              'parallel. By default this is the number of cpus')
+    parser.add_argument('--repos-url', '-r', type=str,
+                        default='https://review.openstack.org:443/projects/',
+                        help='The URL of repos that should return JSON')
     args = parser.parse_args()
-    main(args.force, args.delete, args.concurrency)
+    main(args.force, args.delete, args.concurrency, args.repos_url)


### PR DESCRIPTION
This PR adds to support GitHub repos. To use this, it needs to be specified `--repos-url` like this. What do you think? Do we already have like this command?

```
 $ ./update --repos-url "https://api.github.com/users/jogo/repos?per_page=1000"
```

TODO
 * Add documents how to use this feature.
