### PR TITLE
Change openstack.org to opendev.org

### DIFF
--- a/update
+++ b/update
@@ -26,7 +26,7 @@ import threading
 import requests
 
 """
-Clone/Fetch all openstack repos from git.openstack.org.
+Clone/Fetch all openstack repos from opendev.org.
 
 Pulls the following orgs: openstack openstack-dev and openstack-infra
 """
@@ -67,8 +67,8 @@ class Project(object):
         return org, name
 
     def _git_uri(self):
-        # Convert to git://git.openstack.org/openstack/tempest
-        return "git://git.openstack.org/%s/%s" % (self.org, self.name)
+        # Convert to git://opendev.org/openstack/tempest
+        return "https://opendev.org/%s/%s" % (self.org, self.name)
 
     def __eq__(self, other):
         return self.full_name == other.full_name
@@ -222,7 +222,7 @@ def skip_project(project_name):
 
 
 def main(create_org_dir, delete_orphaned, concurrency, recurse=False,
-         repos_url='https://review.openstack.org:443/projects/'):
+         repos_url='https://review.opendev.org:443/projects/'):
     def worker():
         """Thread worker."""
         while True:
@@ -243,13 +243,13 @@ def main(create_org_dir, delete_orphaned, concurrency, recurse=False,
     projects_json = ""
     is_os = True
 
-    if (repos_url == 'https://review.openstack.org:443/projects/'):
+    if (repos_url == 'https://review.opendev.org:443/projects/'):
         # List of all openstack repos
-        r = requests.get("https://review.openstack.org:443/projects/")
+        r = requests.get("https://review.opendev.org:443/projects/")
         # strip off first few chars because 'the JSON response body starts with a
         # magic prefix line that must be stripped before feeding the rest of the
         # response body to a JSON parser'
-        # https://review.openstack.org/Documentation/rest-api.html
+        # https://review.opendev.org/Documentation/rest-api.html
         projects_json = r.text[4:]
     elif (repos_url.find('https://api.github.com/') == 0):
         # List of all the specified github repos
@@ -306,7 +306,7 @@ if __name__ == "__main__":
                         help='For projects with git submodules perform a '
                              'recursive clone to also clone the submodules')
     parser.add_argument('--repos-url', '-u', type=str,
-                        default='https://review.openstack.org:443/projects/',
+                        default='https://review.opendev.org:443/projects/',
                         help='The URL of repos that should return JSON')
     args = parser.parse_args()
     main(args.force, args.delete, args.concurrency, args.recurse, args.repos_url)


### PR DESCRIPTION
This commit changes the URL - (git.)openstack.org to the new one -
opendev.org because of the recent migration[0].

[0] http://lists.openstack.org/pipermail/openstack-discuss/2019-April/005417.html