### PR TITLE
Fix SyntaxWarning with literals in Python 3.8

### DIFF
--- a/update
+++ b/update
@@ -86,7 +86,7 @@ class Project(object):
                              stderr=subprocess.PIPE,
                              start_new_session=True)
         stdout, stderr = p.communicate()
-        if p.returncode is not 0:
+        if p.returncode != 0:
             print(stderr)
             raise GitException()
         return stdout
@@ -107,7 +107,7 @@ class Project(object):
         if "master\n" == out.decode():
             # Don't do a git pull if local changes
             command = "git diff --quiet".split(' ')
-            if subprocess.call(command, cwd=git_dir) is 0:
+            if subprocess.call(command, cwd=git_dir) == 0:
                 # if needs a merge, fail
                 command = "git pull --ff-only"
                 out = self.call(command, git_dir)


### PR DESCRIPTION
This commit fixes the warnings when we run update with Python 3.8[1].
This should be fixed because this works by accident in CPython according
to the release note[1].

  $ ./update
  ./update:89: SyntaxWarning: "is not" with a literal. Did you mean "!="?
    if p.returncode is not 0:
  ./update:110: SyntaxWarning: "is" with a literal. Did you mean "=="?
    if subprocess.call(command, cwd=git_dir) is 0:

[1] https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior